### PR TITLE
Added field username for devise form confirmation

### DIFF
--- a/app/views/devise/confirmations/new.html.slim
+++ b/app/views/devise/confirmations/new.html.slim
@@ -1,0 +1,18 @@
+h2 = t('.heading')
+
+= form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post }) do |f|
+  = render 'devise/shared/error_messages', resource: resource
+
+  .field
+    = f.label :username
+    br
+    = f.text_field :username, autofocus: true
+  .field
+    = f.label :email
+    br
+    = f.email_field :email, autocomplete: 'email'
+
+  .actions
+    = f.submit t('.links')
+
+= render 'devise/shared/links'

--- a/config/locales/devise/ru.yml
+++ b/config/locales/devise/ru.yml
@@ -7,6 +7,10 @@ ru:
         leave_blank_if_you_don_t_want_to_change_it: оставьте пустым, если не хотите менять
         unhappy: Не нравится ресурс?
         we_need_your_current_password_to_confirm_your_changes: 'нужно при смене пароля'
+    confirmations:
+      new:
+        heading: 'ВЫСЛАТЬ ПОВТОРНО ПИСЬМО С АКТИВАЦИЕЙ'
+        links: 'Выслать повторно письмо с активацией'
     shared:
       links:
         sign_up: Зарегистрироваться


### PR DESCRIPTION
Исправлена форма отправки письма с активацией - не хватало поля `userename`.